### PR TITLE
Test case: sent invalid image meta

### DIFF
--- a/src/Controllers/CustomerController.js
+++ b/src/Controllers/CustomerController.js
@@ -36,6 +36,14 @@ module.exports = function(dependencies) {
   };
 
   const update = async function (req, res) {
+    const {imageMetaId} = req.body;
+    if (imageMetaId) {
+      const imageMeta = await imageMetaService.get(imageMetaId);
+      if (!imageMeta) {
+        return res.status(400).send('Invalid imageMeta');
+      }
+    }
+
     const {customerId} = req.params;
     const customer = await customerService.get(customerId);
     if (!customer) {

--- a/test/api-endpoints/customer.specs.js
+++ b/test/api-endpoints/customer.specs.js
@@ -7,7 +7,7 @@ const BuildApp = require('../util/BuildApp');
 const CustomerController = require('../../src/Controllers/CustomerController');
 const CustomerRoutes = require('../../src/Routes/customer');
 
-const services = {customerService: {}};
+const services = {customerService: {}, imageMetaService: {}};
 const controllers = {customerController: CustomerController({services})};
 
 const app = BuildApp(services, controllers, CustomerRoutes);
@@ -72,6 +72,22 @@ describe('Customer endpoints', function () {
   });
 
   describe('PUT /api/v1/customer/{customerId}', function () {
+
+    it('Should return 400 if referenced imageMeta is not found', function (done) {
+      services.imageMetaService.get = () => null;
+      const customerId = 2771;
+      const requestBody = {name: 'John', surname: 'Doe', imageMetaId: 99};
+      request(app)
+        .put(`/api/v1/customer/${customerId}`)
+        .set('Authorization', `Bearer ${USER_TOKEN}`)
+        .send(requestBody)
+        .set('Accept', 'application/json')
+        .expect(400, (err, res) => {
+          expect(res.text).to.be.equal('Invalid imageMeta');
+          done();
+        });
+
+    });
 
     it('Should return 401 if client is not authenticated', function (done) {
       const customerId = 1;
@@ -213,6 +229,18 @@ describe('Customer endpoints', function () {
   });
 
   describe('POST /api/v1/customer', function () {
+
+    it('Should return 400 if referenced imageMeta is not found', function (done) {
+      services.imageMetaService.get = () => null;
+      request(app)
+        .post('/api/v1/customer')
+        .set('Authorization', `Bearer ${USER_TOKEN}`)
+        .send({name: 'John', surname: 'Doe', imageMetaId: 9})
+        .expect(400, (err, res) => {
+          expect(res.text).to.be.equal('Invalid imageMeta');
+          done();
+        });
+    });
 
     it('Should return 401 if client is not authenticated', function (done) {
       request(app)


### PR DESCRIPTION
- Cover this use case: client referenced an invalid image meta when creating or updating a customer